### PR TITLE
Configure Renovate - autoclosed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}


### PR DESCRIPTION
## Action Required: Fix Renovate Configuration

There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: `renovate.json`
Error type: The renovate configuration file contains some invalid settings
Message: packageRules[0]: packageRules cannot combine both matchUpdateTypes and allowedVersions. Rule: {"matchUpdateTypes":["major"],"matchDepNames":["gravitational/teleport"],"allowedVersions":"/^[1-9][0-9]*\\.[1-9][0-9]*\\.[0-9]+$/"}


Once you have resolved this problem (in this onboarding branch), Renovate will return to providing you with a preview of your repository's configuration.